### PR TITLE
Add npm support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "main": "dist/index.js",
   "type": "commonjs",
   "repository": "github:val-town/sdk",
+  "homepage": "https://docs.val.town",
+  "bugs": {
+    "url": "https://github.com/val-town/sdk/issues"
+  },
   "license": "MIT",
   "packageManager": "yarn@1.22.22",
   "files": [


### PR DESCRIPTION
## Summary
- add homepage metadata pointing to the public Val Town API docs
- add bugs metadata pointing to the repository issue tracker

## Verification
- node manifest assertion
- git diff --check
- npm pack --dry-run --json --ignore-scripts